### PR TITLE
Update install links and combine Mac & Linux for venv

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -24,15 +24,15 @@ If git is not installed your command prompt will tell you. Follow the instructio
 
 ## Windows
 
-Download the ([git installer]https://git-scm.com/download/windows)
+Download the [git installer](https://git-scm.com/download/windows)
 
-If you are unsure if you need the 32 or 64-bit version, you can ([follow these steps]https://support.microsoft.com/en-us/help/15056/windows-7-32-64-bit-faq)
+If you are unsure if you need the 32 or 64-bit version, you can [follow these steps](https://support.microsoft.com/en-us/help/15056/windows-7-32-64-bit-faq)
 
 Run the .exe file that you downloaded and follow the instructions.
 
 ## Mac OS
 
-Download the ([git installer]https://git-scm.com/download/mac)
+Download the [git installer](https://git-scm.com/download/mac)
 
 open the .dmg file that you downloaded. Run the installer inside and follow the instructions.
 
@@ -50,11 +50,11 @@ $ sudo apt-get install git-all
 ```
 
 # Installing miniconda
-Follow the instructions in the ([miniconda quickstart guide]http://conda.pydata.org/docs/install/quick.html#windows-miniconda-install)
+Follow the instructions in the [miniconda quickstart guide](http://conda.pydata.org/docs/install/quick.html#windows-miniconda-install)
 
-* ([Windows] http://conda.pydata.org/docs/install/quick.html#windows-miniconda-install)
-* ([OS X] http://conda.pydata.org/docs/install/quick.html#os-x-miniconda-install)
-* ([Linux]http://conda.pydata.org/docs/install/quick.html#linux-miniconda-install)
+* [Windows](http://conda.pydata.org/docs/install/quick.html#windows-miniconda-install)
+* [OS X](http://conda.pydata.org/docs/install/quick.html#os-x-miniconda-install)
+* [Linux](http://conda.pydata.org/docs/install/quick.html#linux-miniconda-install)
 
 
 # Testing
@@ -89,7 +89,7 @@ rem typical windows
 # Resources: Where can I learn more?
 
 
-([Using conda]http://conda.pydata.org/docs/using/index.html)
+[Using conda](http://conda.pydata.org/docs/using/index.html)
 
 
 

--- a/venv_overview.md
+++ b/venv_overview.md
@@ -14,7 +14,7 @@ Virtual environments (virtualenv) are tools used to keep projects separate, espe
 Many programmers use virtual environments for all but the most trivial programming tasks. Especially for beginners, tackling this early on builds a valuable skill AND helps eliminate sneaky bugs related to version discrepancies that can be hard to diagnose.
 
 # How do you create a virtual environment? 
-The exact method may vary depending on your system and version of Python. See the Resources section for links to resources that can provide additional guidance. But for our purposes, we will use a tool package created by Continuum Analytics called miniconda ([download here](https://conda.pydata.org/miniconda.html)).
+The exact method may vary depending on your system and version of Python. See the Resources section for links to resources that can provide additional guidance. But for our purposes, we will use a tool package created by Continuum Analytics called miniconda ([download here](http://conda.pydata.org/miniconda.html)).
 
 Miniconda allows you to make virtual enviroments as well as provides easy access to all the benefits you get from the heavyweight tool Anaconda.
 
@@ -28,7 +28,7 @@ conda create -n mycalc python=3
 Once you have created a virtualenv you need to activate it AND then populate it with software.
 
 ## Activating your virtualenv
-### Linux version
+### Linux\Mac OSX version
 ```bash
 $ source mycalc/bin/activate
 ```
@@ -49,7 +49,7 @@ pip install ipython
 # How do you get out of the virtual environment when you are done? 
 When you are done working in your virtualenv, you can deactivate it using the following command:
 
-### Linux version
+### Linux\Mac OSX version
 ```bash
 # typical linux
 (mycalc) $ deactivate


### PR DESCRIPTION
The https for conda.pydata.org/miniconda.html was failing when I looked over the instructions, which is why I changed it. The rest are formatting changed and including Mac OSX where it is the same as Linux.