### PR TITLE
Avoid confusing characters

### DIFF
--- a/class_materials/github_setup.md
+++ b/class_materials/github_setup.md
@@ -49,7 +49,7 @@ Fork the [Codeless Project](https://github.com/chalmerlowe/intro_to_sprinting_co
 
 ## The big picture
 
-Project files on Github are often called repositories or **repo/repos** for short. For every project you contribute to, you will interact with two different repos:
+Project files on Github are often called repositories, or a **repo** for short. For every project you contribute to, you will interact with two different repos:
 
 * One repo will be the original project repository
 * The other repo will be **your personal copy** of the original repo


### PR DESCRIPTION
This removes

> repo/repos

and replaces it with

> a repo

which can seem like a trivial change, but FWIW I got confused because I thought the old text meant that repo/repos was a path, or that the first one was an organization name in GitHub.