### PR TITLE
Updating to switch and restore commands

### DIFF
--- a/class_materials/git_branch_merge.md
+++ b/class_materials/git_branch_merge.md
@@ -11,7 +11,7 @@
 
 With larger projects, it is very common to create **branches** and then **merge** the branches into the project's main branch when finalize your changes. You've seen references to `main` in earlier lessons. `main` is the default branch (you may also see primary or default branches referred to as `master` in legacy projects). A typical enhancement would be done by:
 
-1. creating a branch (so you have a separate workspace to work in) using `git checkout -b <branch name>`
+1. creating a branch (so you have a separate workspace to work in) using `git switch --create <branch name>`
 1. doing your work as a series of `git add` and `git commit` cycles to the branch
 1. merging your changes with `main`
 1. submitting a pull request to the project owner (covered in a separate discussion)
@@ -31,7 +31,7 @@ Do the following steps to get a feel for a typical iteration of creating a featu
 **Create a new branch** & cause `git` to begin tracking changes in that branch
 
 ```bash
-$ git checkout -b appleseed-feature     # "-b" creates a new branch named "appleseed-feature"
+$ git switch --create appleseed-feature     # "--create", or "-c", creates a new branch named "appleseed-feature"
 ```
 
 **Do work/edit files**
@@ -56,13 +56,13 @@ $ git add jabberwocky.txt
 $ git commit -m "my second bit of work"
 ```
 
-**Checkout the master branch** and prepare to merge all our changes with any other changes that have been accepted into the upstream codebase...
+**Switch to the main branch** and prepare to merge all our changes with any other changes that have been accepted into the upstream codebase...
 
 ```bash
-$ git checkout main            # this checks out the master branch
+$ git switch main            # this switches/checks out the main branch and is the same as "git checkout main"
 ```
 
-**Update our local copy** ... Before we try to merge our changes to master, let's update our local copy of the repo with any updates that might have occurred in the `upstream` version by using `git pull`.
+**Update our local copy** ... Before we try to merge our changes to main, let's update our local copy of the repo with any updates that might have occurred in the `upstream` version by using `git pull`.
 
 ```bash
 $ git pull upstream main       # this pulls any upstream changes into your computer
@@ -78,7 +78,7 @@ $ git pull origin main         # Generally not necessary, but this pulls
 **Merge local changes from main into our local copy of appleseed-feature** ... With the latest and greatest `upstream` (and/or `origin`) changes on your local machine, attempt to merge `main` with your local copy of `appleseed-feature`. We do this by checking out `appleseed-feature` and then merging it with any changes from `main`.
 
 ```bash
-$ git checkout appleseed-feature
+$ git switch appleseed-feature # again, the same as "git checkout appleseed-feature"
 $ git merge main
 ```
 
@@ -94,7 +94,7 @@ If you (and your partner, if you're working in pairs) are done, then you can put
 
 ## The big picture
 
-Let's imagine that you are working on a project with multiple commits to the master branch and a single bug fix branch to fix Issue #53 called `iss53`. Commits `C3` and `C5` are the changes that were committed on the branch, and `C4` is a change made by someone else to the master branch during that same timeframe.
+Let's imagine that you are working on a project with multiple commits to the main branch and a single bug fix branch to fix Issue #53 called `iss53`. Commits `C3` and `C5` are the changes that were committed on the branch, and `C4` is a change made by someone else to the main branch during that same timeframe.
 
 The history created by the above steps would look something like this:
 
@@ -112,10 +112,10 @@ Besides `git add`, `git commit`, `git push`, a next logical step in preparing to
 
 ### Create a branch
 
-**Note:** replace "appleseed-feature" with the name of the feature you are adding. The `git checkout` command allows you to change to a new branch. If that branch does not exist yet, it can be created with the `-b` option.
+**Note:** replace "appleseed-feature" with the name of the feature you are adding. The `git switch` command allows you to change to a new branch. If that branch does not exist yet, it can be created with the `--create` (the same as `-c`) option.
 
 ```bash
-$ git checkout -b appleseed-feature
+$ git switch -c appleseed-feature
 ```
 
 What makes a good branch name? What are the rules for naming branches? This is a short list of rules (for a complete list, see the [git man pages](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html).
@@ -140,16 +140,16 @@ $ git add johnny_appleseed.txt
 $ git commit -m "added edits to johnny's history"
 ```
 
-### Merge your changes into the master branch
+### Merge your changes into the main branch
 
-As noted above, `git checkout` allows you to change to an alternate branch. The `main` branch is created by default by `git` and is often used as the primary branch for release. To change back to the `main` branch, use `git checkout main`. Often others may be working on the same codebase and some of those changes may impact your codebase, so it is critical to collect all of those changes (i.e. download them from the `upstream` repository) for comparison to your code, using `git pull`.
+As noted above, `git switch` allows you to change to an alternate branch. The `main` branch is created by default by `git` and is often used as the primary branch for release. To change back to the `main` branch, use `git switch main`. Often others may be working on the same codebase and some of those changes may impact your codebase, so it is critical to collect all of those changes (i.e. download them from the `upstream` repository) for comparison to your code, using `git pull`.
 
 For now, we will presume that there are no conflicts between your changes and other changes. With that premise in mind, you can merge your code and your local copy of the `upstream` repo.
 
 ```bash
-$ git checkout main
+$ git switch main
 $ git pull
-$ git checkout appleseed-feature
+$ git switch appleseed-feature
 $ git merge main
 ```
 
@@ -169,7 +169,7 @@ $ git push origin appleseed-feature
 * [Advanced Git](https://youtu.be/4EOZvow1mk4) - a great talk about some commands that will make working with multiple branches easier
 
 <!-- begin auto-generated nav-links section -->
-| Previous | Up | Next |
-|:---------|:---:|-----:|
+| Previous                                            |               Up               |                                        Next |
+| :-------------------------------------------------- | :----------------------------: | ------------------------------------------: |
 | [Git Common Operations](./git_common_operations.md) | [Using Git](./git_overview.md) | [Merge Conflicts](./git_merge_conflicts.md) |
 <!-- end auto-generated section -->

--- a/class_materials/git_cloning.md
+++ b/class_materials/git_cloning.md
@@ -103,8 +103,8 @@ Again, if you are curious, you can confirm that `git` has stored the correct ups
 $ git remote -v
 origin   https://github.com/johnny_appleseed/intro_to_sprinting_codeless_project (fetch)
 origin   https://github.com/johnny_appleseed/intro_to_sprinting_codeless_project (push)
-upstream https://github.com/chalmerlowe/intro_to_sprinting_codeless_project (fetch)
-upstream https://github.com/chalmerlowe/intro_to_sprinting_codeless_project (push)
+upstream        https://github.com/chalmerlowe/intro_to_sprinting_codeless_project (fetch)
+upstream        https://github.com/chalmerlowe/intro_to_sprinting_codeless_project (push)
 ```
 
 **Note:** You'll only do this **one time for each project** you want to work on.
@@ -115,7 +115,7 @@ upstream https://github.com/chalmerlowe/intro_to_sprinting_codeless_project (pus
 * [Git Basics - Getting a Git Repository](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository)
 
 <!-- begin auto-generated nav-links section -->
-| Previous | Up | Next |
-|:---------|:---:|-----:|
+| Previous                          |               Up               |                                                               Next |
+| :-------------------------------- | :----------------------------: | -----------------------------------------------------------------: |
 | [Git Concepts](./git_concepts.md) | [Using Git](./git_overview.md) | [Git Primary Workflow: Add, Commit, Push](./git_main_lifecycle.md) |
 <!-- end auto-generated section -->

--- a/class_materials/git_common_operations.md
+++ b/class_materials/git_common_operations.md
@@ -31,10 +31,10 @@ This will show you, in detail, the differences between the last version of the f
 
 Once you are done, you can restore the modified file to it's original state by typing:
 ```bash
-`git checkout -- beowulf.txt`
+$ git restore beowulf.txt
 ```
 
-This essentialy tells git to "undo" any changes to that file that are not yet staged or committed.
+This essentialy tells git to "undo" any changes to that file that are not yet staged or committed. Note that this is the same as `git checkout -- beowulf.txt`.
 
 ## Done with commands for now!
 
@@ -164,7 +164,7 @@ Many GUI-based tools will show you more information, such as highlighting the in
 * [Git Basics - Recording Changes to the Repository](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository)
 
 <!-- begin auto-generated nav-links section -->
-| Previous | Up | Next |
-|:---------|:---:|-----:|
+| Previous                                                           |               Up               |                                           Next |
+| :----------------------------------------------------------------- | :----------------------------: | ---------------------------------------------: |
 | [Git Primary Workflow: Add, Commit, Push](./git_main_lifecycle.md) | [Using Git](./git_overview.md) | [Branching and Merging](./git_branch_merge.md) |
 <!-- end auto-generated section -->

--- a/class_materials/git_merge_conflicts.md
+++ b/class_materials/git_merge_conflicts.md
@@ -49,7 +49,7 @@ Similarly, if their changes are in the same file that we changed, but are in com
 1. Create and switch to a new branch called `conflict-merge` by typing the following on your command line:
 
     ```bash
-    $ git checkout -b conflict-merge
+    $ git switch -c conflict-merge
     ```
 
 1. Open `conflict_lesson.txt` in your **local repository** with a text editor.
@@ -72,7 +72,7 @@ Similarly, if their changes are in the same file that we changed, but are in com
 1. Switch back to the `main` branch
 
     ```bash
-    $ git checkout main
+    $ git switch main
     ```
 
 1. **Pull down the changes you made on your GitHub repo** by pulling from `origin main`
@@ -83,10 +83,10 @@ Similarly, if their changes are in the same file that we changed, but are in com
 
     > **NOTE**: as mentioned in the previous lesson, normally, you would prioritize getting changes from `upstream` by pulling from `upstream main`, but since you made your changes to **your** GitHub repo, we are using this as a **workaround** for the purposes of this lesson.
 
-1. Checkout your branch `conflict-merge` using:
+1. Switch to your branch `conflict-merge` using:
 
     ```bash
-    $ git checkout conflict-merge
+    $ git switch conflict-merge
     ```
 
 1. Attempt to merge the versions in your `main` branch and your `conflict-merge` branch using the `merge` command:
@@ -197,7 +197,7 @@ It is not necessary, for this simple example, to add text to the empty fields. N
 **Create and switch to a new branch** called `conflict-merge`. Since this branch doesn't yet exist, we need to create it by using the `-b` flag.
 
 ```bash
-$ git checkout -b conflict-merge
+$ git switch -c conflict-merge
 ```
 
 **Edit the file conflict_lesson.txt locally:**
@@ -232,7 +232,7 @@ The customary workflow is to:
 Let's continue by checking out `main` so we can update it.
 
 ```bash
-$ git checkout main
+$ git switch main
 ```
 
 **Pull down the changes you made on your GitHub repo** by pulling from `origin main`
@@ -241,7 +241,7 @@ $ git checkout main
 $ git pull origin main
 ```
 
-**NOTE**: as mentioned in the previous lesson, normally, you would prioritize getting changes from `upstream` by using `git pull upstream master`, but since you made your changes to **your** GitHub repo, we are using `origin` as a workaround for the purposes of this lesson.
+**NOTE**: as mentioned in the previous lesson, normally, you would prioritize getting changes from `upstream` by using `git pull upstream main`, but since you made your changes to **your** GitHub repo, we are using `origin` as a workaround for the purposes of this lesson.
 
 **Attempt to merge** the versions in your `main` branch and your `conflict-merge` branch using the `merge` command:
 
@@ -357,7 +357,7 @@ $ git push
 * [Git advanced merging](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_advanced_merging)
 
 <!-- begin auto-generated nav-links section -->
-| Previous | Up | Next |
-|:---------|:---:|-----:|
+| Previous                                       |               Up               |                                 Next |
+| :--------------------------------------------- | :----------------------------: | -----------------------------------: |
 | [Branching and Merging](./git_branch_merge.md) | [Using Git](./git_overview.md) | [Using GitHub](./github_overview.md) |
 <!-- end auto-generated section -->

--- a/class_materials/git_overview.md
+++ b/class_materials/git_overview.md
@@ -35,6 +35,7 @@ There are Graphical User Interface (GUI) tools available as well, but they are b
 
 * [gitk](https://lostechies.com/joshuaflanagan/2010/09/03/use-gitk-to-understand-git/)
 * [SourceTree](https://www.sourcetreeapp.com/)
+* [GitHub Desktop](https://desktop.github.com/)
 
 ... and there are many others.
 
@@ -53,7 +54,7 @@ There are Graphical User Interface (GUI) tools available as well, but they are b
 * [Getting Started - Git Basics](https://git-scm.com/book/en/v2/Getting-Started-Git-Basics)
 
 <!-- begin auto-generated nav-links section -->
-| Previous | Up | Next |
-|:---------|:---:|-----:|
+| Previous                          |                Up                |                              Next |
+| :-------------------------------- | :------------------------------: | --------------------------------: |
 | [Setting up Git](./git_config.md) | [Table of Contents](./README.md) | [Git Concepts](./git_concepts.md) |
 <!-- end auto-generated section -->


### PR DESCRIPTION
Updated the docs to use the "switch" and "restore" commands rather than "checkout" as it is the more modern approach and likely more beginner-friendly.
Also found some references to "master", so changed those to "main" instead.
VS code/Black also reformatted the menu sections at the bottom of the pages to space them for alignment.